### PR TITLE
Use link_pages Instead of post_navigation for multipage posts

### DIFF
--- a/page.php
+++ b/page.php
@@ -18,7 +18,7 @@ get_header();
 
 			get_template_part( 'template-parts/content/content', get_post_type() );
 			
-			the_post_navigation();
+			wp_link_pages();
 
 			if ( comments_open() ) :
 				comments_template();

--- a/single.php
+++ b/single.php
@@ -18,11 +18,13 @@ get_header();
 
 			get_template_part( 'template-parts/content/content', get_post_type() );
 			
-			the_post_navigation();
+			wp_link_pages();
 
 			if ( comments_open() ) :
 				comments_template();
 			endif;
+
+			the_post_navigation();
 
 		endwhile;
 		?>


### PR DESCRIPTION
### What Was Accomplished

- Updated single and page templates to use the right functions for multipage posts as opposed to next/previous posts.
- Pages will not have next/previous, but can be multipage.