### PR TITLE
Remove .site / #page

### DIFF
--- a/assets/src/less/components/site.less
+++ b/assets/src/less/components/site.less
@@ -1,7 +1,0 @@
-/**
- * Site
- * .site wraps everything. It is the first visible block
- * after the screen-reader only skip link.
- */
-
-// .site {}

--- a/comments.php
+++ b/comments.php
@@ -15,7 +15,7 @@ if ( post_password_required() ) {
 	return;
 }
 ?>
-<div class="area--comments comments" id="comments">
+<div class="comments" id="comments">
 	<h2 class="comments__title"><?php esc_html_e( 'Comments', 'cata' ); ?></h2>
 	<?php if ( have_comments() ) : ?>
 		<ol>

--- a/footer.php
+++ b/footer.php
@@ -9,10 +9,10 @@
  */
 
 ?>
-<footer class="site__footer" id="footer" role="contentinfo">
+<footer class="footer" id="footer" role="contentinfo">
 	<p>
 	<?php if ( function_exists( 'vip_powered_wpcom' ) ) : ?>
-		<?php vip_powered_wpcom(); ?>
+		<?php echo wp_kses_posty( vip_powered_wpcom() ); ?>
 	<?php else : ?>
 		<a href="<?php echo esc_url( __( 'https://wordpress.org', 'cata' ) ); ?>">
 			<?php

--- a/header.php
+++ b/header.php
@@ -11,23 +11,23 @@
 get_template_part( 'template-parts/document/document', 'open' );
 get_template_part( 'template-parts/skip-link' );
 ?>
-<header class="site__header" id="header" role="banner">
+<header class="header" id="header" role="banner">
 	<hgroup>
-		<h1 class="site__title">
+		<h1 class="header__title">
 			<a href="<?php echo esc_url( home_url() ); ?>"><?php bloginfo( 'name' ); ?></a>
 		</h1>
 		<?php if ( get_bloginfo( 'description' ) ) : ?>
-		<span class="site__description"><?php bloginfo( 'description', 'display' ); ?></span>
+		<span class="header__description"><?php bloginfo( 'description', 'display' ); ?></span>
 		<?php endif; ?>
 	</hgroup>
-	<nav class="site__navigation" id="siteNav">
+	<nav class="header__navigation" id="headerNav">
 	<?php
 
 	/*
 	Output:
-	<nav class="site__navigation" id="siteNav" role="navigation">
-		<div class="menu--site">
-			<ul class="menu" id="siteNavMenu">
+	<nav class="header__navigation" id="headerNav" role="navigation">
+		<div class="menu--header">
+			<ul class="menu" id="headerNavMenu">
 				<li class="menu-item"><a>Link</a></li>
 			</ul>
 		</div>
@@ -36,9 +36,9 @@ get_template_part( 'template-parts/skip-link' );
 
 	wp_nav_menu(
 		array(
-			'theme_location'  => 'site-nav',
-			'menu_id'         => 'siteNavMenu',
-			'container_class' => 'menu--site',
+			'theme_location'  => 'header-nav',
+			'menu_id'         => 'headerNavMenu',
+			'container_class' => 'menu--header',
 		)
 	);
 	?>

--- a/includes/nav-menus/class-nav-menus.php
+++ b/includes/nav-menus/class-nav-menus.php
@@ -28,7 +28,7 @@ if ( ! class_exists( 'Cata\Nav_Menus' ) ) :
 		public static function register_nav_menus() : void {
 			
 			$nav_menu_options = array(
-				'site-nav' => esc_html__( 'Primary Navigation', 'cata' ),
+				'header-nav' => esc_html__( 'Primary Navigation', 'cata' ),
 			);
 			
 			register_nav_menus( $nav_menu_options );

--- a/index.php
+++ b/index.php
@@ -7,32 +7,19 @@
  */
 
 get_header();
-?>
-<div class="site__content" id="content">
-	<section class="site__primary area--content" id="primary">
-		<main class="site__main" id="main">
-		<?php
-		if ( have_posts() ) {
-			while ( have_posts() ) {
-
-				the_post();
-
-				if ( is_singular() ) {
-					get_template_part( 'template-parts/content/content', get_post_type() );
-				} else { 
-					get_template_part( 'template-parts/preview/preview', get_post_type() );
-				}
-			}
-
-			the_posts_navigation();
-
-		} else {
-			get_template_part( 'template-parts/content/content', 'none' );
-		}
-		?>
-		</main>
-	</section>
-	<?php get_sidebar(); ?>
-</div>
-<?php
+get_template_part( 'woocommerce/global/wrapper', 'start' );
+if ( have_posts() ) :
+	while ( have_posts() ) :
+		the_post();
+		if ( is_singular() ) :
+			get_template_part( 'template-parts/content/content', get_post_type() );
+		else :
+			get_template_part( 'template-parts/preview/preview', get_post_type() );
+		endif;
+	endwhile;
+	the_posts_navigation();
+else :
+	get_template_part( 'template-parts/content/content', 'none' );
+endif;
+get_template_part( 'woocommerce/global/wrapper', 'end' );
 get_footer();

--- a/page.php
+++ b/page.php
@@ -7,28 +7,14 @@
  */
 
 get_header();
-?>
-<div class="site__content" id="content">
-	<section class="site__primary area--content" id="primary">
-		<main class="site__main" id="main">
-		<?php
-		while ( have_posts() ) :
-
-			the_post();
-
-			get_template_part( 'template-parts/content/content', get_post_type() );
-			
-			wp_link_pages();
-
-			if ( comments_open() ) :
-				comments_template();
-			endif;
-
-		endwhile;
-		?>
-		</main>
-	</section>
-	<?php get_sidebar(); ?>
-</div>
-<?php
+get_template_part( 'woocommerce/global/wrapper', 'start' );
+while ( have_posts() ) :
+	the_post();
+	get_template_part( 'template-parts/content/content', get_post_type() );
+	wp_link_pages();
+	if ( comments_open() ) :
+		comments_template();
+	endif;
+endwhile;
+get_template_part( 'woocommerce/global/wrapper', 'end' );
 get_footer();

--- a/sidebar.php
+++ b/sidebar.php
@@ -8,7 +8,7 @@
  */
 
 ?>
-<section class="site__secondary area--widget" id="secondary" role="complementary">
+<section class="secondary" id="secondary" role="complementary">
 	<?php
 	if ( is_active_sidebar( 'cata-sidebar' ) ) {
 		dynamic_sidebar( 'cata-sidebar' );

--- a/single.php
+++ b/single.php
@@ -7,28 +7,14 @@
  */
 
 get_header();
-?>
-<div class="site__content" id="content">
-	<section class="site__primary area--content" id="primary">
-		<main class="site__main" id="main">
-		<?php
-		while ( have_posts() ) :
-
-			the_post();
-
-			get_template_part( 'template-parts/content/content', get_post_type() );
-
-			if ( comments_open() ) :
-				comments_template();
-			endif;
-
-			the_post_navigation();
-
-		endwhile;
-		?>
-		</main>
-	</section>
-	<?php get_sidebar(); ?>
-</div>
-<?php
+get_template_part( 'woocommerce/global/wrapper', 'start' );
+while ( have_posts() ) :
+	the_post();
+	get_template_part( 'template-parts/content/content', get_post_type() );
+	if ( comments_open() ) :
+		comments_template();
+	endif;
+	the_post_navigation();
+endwhile;
+get_template_part( 'woocommerce/global/wrapper', 'end' );
 get_footer();

--- a/woocommerce/global/wrapper-end.php
+++ b/woocommerce/global/wrapper-end.php
@@ -9,4 +9,5 @@
 ?>
 		</main><!-- #main -->
 	</section><!-- #primary -->
+	<?php get_sidebar(); ?>
 </div><!-- #content -->

--- a/woocommerce/global/wrapper-start.php
+++ b/woocommerce/global/wrapper-start.php
@@ -7,6 +7,6 @@
  */
 
 ?>
-<div class="site__content" id="content">
-	<section class="site__primary area--content" id="primary">
-		<main class="site__main" id="main">
+<div class="content" id="content">
+	<section class="primary" id="primary">
+		<main class="main" id="main">


### PR DESCRIPTION
### What Was Accomplished

- Removed the #page element that wraps all the content.
  - It becomes the devil when something like the Pinterest save button is appended to the end of the body and you want it to be in front of the content but behind the header.
- Re-used the woocommerce global wrapper stand and end instead of copying the same elements  into each root level template file. 