### PR TITLE
Update Sizes Attribute in Images within Specified Content Blocks

### DIFF
--- a/includes/bootstrap.php
+++ b/includes/bootstrap.php
@@ -8,6 +8,9 @@
 namespace Cata;
 
 new Enqueue_Assets();
+new Images\Block_Image_Sizes\Setter(
+	new Images\Block_Image_Sizes\Getter()	
+);
 new Images\Image_Sizes(
 	new Images\Content_Width()
 );

--- a/includes/images/block-image-sizes/getter/class-getter.php
+++ b/includes/images/block-image-sizes/getter/class-getter.php
@@ -1,0 +1,115 @@
+<?php
+/**
+ * Block Image Size Getter
+ * 
+ * @package Cata\Images\Block_Image_Sizes
+ * @since 0.3.0
+ */
+
+namespace Cata\Images\Block_Image_Sizes;
+
+/**
+ * Getter
+ */
+class Getter {
+
+	/**
+	 * Default
+	 * 
+	 * @var string $default
+	 */
+	public $default = '(max-width:768px) 92.5vw, 768px';
+
+	/**
+	 * Construct
+	 * 
+	 * @param string $default - override default sizes values.
+	 */
+	public function __construct( string $default = '' ) {
+
+		if ( '' !== $default ) {
+			$this->default = $default;
+		}
+
+		add_filter( 'cata_get_block_image_sizes_core/image', array( $this, 'core_image' ), 10, 3 );
+		add_filter( 'cata_get_block_image_sizes_core/media-text', array( $this, 'core_media_text' ), 10, 3 );
+
+	}
+
+	/**
+	 * Get Block Image Sizes
+	 * 
+	 * @param  string $image - an img tag.
+	 * @param  array  $block - array representation of block.
+	 * @return string $sizes - what to put in the img sizes attribute.
+	 */
+	public function get_block_image_sizes( string $image, array $block ) : string {
+
+		return apply_filters( "cata_get_block_image_sizes_{$block['blockName']}", $this->default, $image, $block );
+
+	}
+
+	/**
+	 * Get Block Names
+	 * 
+	 * @return array - name of blocks that should have image sizes applied to them.
+	 */
+	public function get_block_names() {
+
+		$default_block_names = array(
+			'core/image',
+			'core/media-text',
+		); 
+
+		return apply_filters( 'cata_get_block_names', $default_block_names ); 
+
+	}
+
+	/**
+	 * WP Block - Core Image
+	 * 
+	 * @param  string $sizes - default sizes attribute value.
+	 * @param  string $image - img tag as string.
+	 * @param  array  $block - array representation of block.
+	 * @return string $sizes - updated sizes attribute value.
+	 */
+	public function core_image( string $sizes, string $image, array $block ) : string {
+
+		if ( ! isset( $block['attrs']['align'] ) ) {
+			return $this->default;
+		}
+
+		if ( 'wide' === $block['attrs']['align'] ) {
+			$sizes = '(max-width:1280px) 92.5vw, 1280px';
+		} elseif ( 'full' === $block['attrs']['align'] ) {
+			$sizes = '(max-width:1536px) 100vw, 1536px';
+		}
+
+		return $sizes;
+
+	}
+
+	/**
+	 * WP Block - Core Media-Text
+	 * We cannot ascertain the value of the align property for any setting
+	 * other than full. Assumed to be at least alignwide.
+	 * 
+	 * @link https://github.com/WordPress/gutenberg/issues/15476 
+	 * @param  string $sizes - default sizes attribute value.
+	 * @param  string $image - img tag as string.
+	 * @param  array  $block - array representation of block.
+	 * @return string $sizes - updated sizes attribute value.
+	 */
+	public function core_media_text( string $sizes, string $image, array $block ) {
+		
+		$sizes = '50vw';
+
+		if ( isset( $block['attrs']['isStackedOnMobile'] ) && true === $block['attrs']['isStackedOnMobile'] ) {
+			$sizes = $this->default;
+		}
+
+		return $sizes;
+
+	}
+
+}

--- a/includes/images/block-image-sizes/setter/class-setter.php
+++ b/includes/images/block-image-sizes/setter/class-setter.php
@@ -1,0 +1,101 @@
+<?php 
+/**
+ * Block Image Size Setter
+ * 
+ * @package Cata\Images\Block_Image_Sizes
+ * @since 0.3.0
+ */
+
+namespace Cata\Images\Block_Image_Sizes;
+
+/**
+ * Setter
+ */
+class Setter {
+
+	/**
+	 * Getter
+	 * 
+	 * @var Getter $getter
+	 */
+	public $getter;
+
+	/**
+	 * Construct
+	 * 
+	 * @param Getter $getter - instance of Getter class.
+	 */
+	public function __construct( Getter $getter ) {
+
+		$this->getter = $getter;
+
+		add_filter( 'render_block', array( $this, 'set_image_sizes_in_block' ), 10, 2 );
+
+	}
+
+	/**
+	 * Add Image Sizes to Block
+	 * 
+	 * @param  string $block_content - provided html content of block.
+	 * @param  array  $block - array representation of block.
+	 * @return string $block_content - updated html content of block.
+	 */
+	public function set_image_sizes_in_block( string $block_content, array $block ) : string {
+
+		if ( ! preg_match_all( '/<img [^>]+>/', $block_content, $matches ) ) {
+			return $block_content;
+		}
+
+		if ( ! $this->should_set_image_sizes_in_block( $block ) ) {
+			return $block_content;
+		}
+
+		foreach ( $matches[0] as $image ) {
+
+			$block_content = str_replace( $image, $this->set_image_sizes( $image, $block ), $block_content );
+			
+		}
+
+		return $block_content;
+
+	}
+
+	/**
+	 * Should Add Image Sizes to Block
+	 * 
+	 * @param  array $block - array representation of block.
+	 * @return bool  $block_uses_image_sizes - whether or not this block utilizes responsive image sizes.
+	 */
+	public function should_set_image_sizes_in_block( array $block ) : bool {
+
+		$block_names = $this->getter->get_block_names();
+		
+		$block_uses_image_sizes = in_array( $block['blockName'], $block_names, true );
+
+		return apply_filters( 'cata_should_set_image_sizes_in_block', $block_uses_image_sizes );
+
+	}
+
+	/**
+	 * Add Sizes to Image
+	 * 
+	 * @param  string $image - provided img tag.
+	 * @param  array  $block - array representation of block.
+	 * @return string $image - updated img tag.
+	 */
+	public function set_image_sizes( string $image, array $block ) : string {
+
+		$sizes = $this->getter->get_block_image_sizes( $image, $block );
+
+		if ( '' !== $sizes ) {
+
+			$attr  = sprintf( ' sizes="%s"', esc_attr( $sizes ) );
+			$image = preg_replace( '/<img ([^>]+?)[\/ ]*>/', '<img $1' . $attr . ' />', $image );
+
+		}
+
+		return apply_filters( 'cata_set_image_sizes', $image, $block );
+
+	}
+
+}

--- a/includes/images/image-sizes/class-image-sizes.php
+++ b/includes/images/image-sizes/class-image-sizes.php
@@ -72,11 +72,11 @@ class Image_Sizes {
 	 */
 	public function get_editor_image_sizes() : array {
 		return array(
-			'thumbnail'    => __( 'Small', 'cata' ),
-			'medium_large' => __( 'Default', 'cata' ),
-			'1536x1536'    => __( 'Wide', 'cata' ),
-			'2048x2048'    => __( 'Full', 'cata' ),
-			'full'         => __( 'Original', 'cata' ),
+			'thumbnail'      => __( 'Small', 'cata' ),
+			'medium_large'   => __( 'Default', 'cata' ),
+			'post-thumbnail' => __( 'Wide', 'cata' ),
+			'1536x1536'      => __( 'Full', 'cata' ),
+			'full'           => __( 'Original', 'cata' ),
 		);
 	}
 


### PR DESCRIPTION
### Was Accomplished

- Added Block_Image_Sizes Getter and Setter classes which we've used previously on Clearing Farm, and I've tested successfully on Creepy Catalog.
  - By default WordPress uses a size attribute like `(max-width:${image-size}) 100vw, ${image-size}`
  - Jetpack overrides this in the content with `(max-width:${content-width}) 100vw, ${content-width}`
  - WordPress's original is closer to reality, but still requires the author to select the correct image size for the width of the content. Our version lets the theme set the sizes attribute based on whether the block's alignment is default, wide or full — making image size selection almost automatic.
- Updated `get_editor_image_sizes` because post thumbnails and alignwide are both 64rem.