### PR TITLE
isStackOnMobile deprecated

### DIFF
--- a/includes/images/block-image-sizes/getter/class-getter.php
+++ b/includes/images/block-image-sizes/getter/class-getter.php
@@ -104,7 +104,7 @@ class Getter {
 		
 		$sizes = '50vw';
 
-		if ( isset( $block['attrs']['isStackedOnMobile'] ) && true === $block['attrs']['isStackedOnMobile'] ) {
+		if ( false !== strpos( $block['innerHTML'], 'is-stacked-on-mobile' ) ) {
 			$sizes = $this->default;
 		}
 

--- a/includes/images/block-image-sizes/getter/class-getter.php
+++ b/includes/images/block-image-sizes/getter/class-getter.php
@@ -104,7 +104,7 @@ class Getter {
 		
 		$sizes = '50vw';
 
-		if ( false !== strpos( $block['innerHTML'], 'is-stacked-on-mobile' ) ) {
+		if ( isset( $block['innerHTML'] ) && false !== strpos( $block['innerHTML'], 'is-stacked-on-mobile' ) ) {
 			$sizes = $this->default;
 		}
 


### PR DESCRIPTION
### What Was Accomplished

- In Wordpress 5.4, isStackOnMobile is no longer set in Media/Text blocks.