### PR TITLE
Add Block Editor Format for <mark> inline element

### DIFF
--- a/assets/dist/js/block-editor-format-mark.js
+++ b/assets/dist/js/block-editor-format-mark.js
@@ -1,0 +1,59 @@
+/**
+ * Mark Format 
+ */
+( function( wp ) {
+
+	/**
+	 * @link https://material.io/resources/icons/?icon=border_color&style=baseline
+	 */
+	const icon = wp.element.createElement( 'svg', {
+		children: [
+			wp.element.createElement( 'path', {
+				d: 'M22,24H2v-4h20V24z M13.06,5.19l3.75,3.75L7.75,18H4v-3.75L13.06,5.19z M17.88,7.87l-3.75-3.75 l1.83-1.83c0.39-0.39,1.02-0.39,1.41,0l2.34,2.34c0.39,0.39,0.39,1.02,0,1.41L17.88,7.87z'
+			})
+		]
+	} );
+
+	const MarkButton = function( props ) {
+		return wp.element.createElement(
+			wp.editor.RichTextToolbarButton,
+			{
+				icon: icon,
+				title: 'Mark / Highlight',
+				style: 'margin-block-end: 8px;',
+			   	onClick: function() {
+					props.onChange( wp.richText.toggleFormat(
+						props.value,
+						{ type: 'cata/mark' }
+					) );
+				},
+				isActive: props.isActive
+			}
+		);
+	};
+	
+	const ConditionalButton = wp.compose.compose(
+		wp.data.withSelect( function( select ) {
+			return {
+				selectedBlock: select( 'core/editor' ).getSelectedBlock()
+			}
+		} ),
+		wp.compose.ifCondition( function( props ) {
+			return (
+				props.selectedBlock &&
+				props.selectedBlock.name === 'core/paragraph'
+			);
+		} )
+	)( MarkButton );
+	
+	wp.richText.registerFormatType(
+		'cata/mark',
+		{
+			title: 'Mark / Highlight',
+			tagName: 'mark',
+			className: null,
+			edit: ConditionalButton
+		}
+	);
+
+} )( window.wp );

--- a/includes/bootstrap.php
+++ b/includes/bootstrap.php
@@ -7,6 +7,7 @@
 
 namespace Cata;
 
+new Custom_Formats\Mark();
 new Enqueue_Assets();
 new Images\Block_Image_Sizes\Setter(
 	new Images\Block_Image_Sizes\Getter()	

--- a/includes/custom-formats/mark/class-mark.php
+++ b/includes/custom-formats/mark/class-mark.php
@@ -1,0 +1,45 @@
+<?php
+/**
+ * <mark> Custom Format for Block Editor
+ * 
+ * @link https://developer.wordpress.org/block-editor/tutorials/format-api/
+ * @package Cata\Custom_Formats
+ * @since 0.1.5
+ */
+
+namespace Cata\Custom_Formats;
+
+/**
+ * Mark
+ */
+class Mark {
+
+	/**
+	 * Construct
+	 */
+	public function __construct() {
+		add_action( 'init', array( __CLASS__, 'register_format' ) );
+		add_action( 'enqueue_block_editor_assets', array( __CLASS__, 'enqueue_assets' ) );
+	}
+
+	/**
+	 * Register Format
+	 */
+	public static function register_format() : void {
+		wp_register_script(
+			'cata-block-editor-format-mark',
+			get_stylesheet_directory_uri() . '/assets/dist/js/block-editor-format-mark.js',
+			array( 'wp-rich-text', 'wp-element', 'wp-editor', 'wp-compose', 'wp-data' ),
+			wp_get_theme()->get( 'Version' ),
+			true
+		);
+	}
+
+	/**
+	 * Enqueue Assets
+	 */
+	public static function enqueue_assets() : void {
+		wp_enqueue_script( 'cata-block-editor-format-mark' );
+	}
+
+}


### PR DESCRIPTION
### Background

We did this previously on Clearing Farm, so I copied most of this right from there. The only things that changed are the names of functions and the icon. The dashicons I would normally use for this aren't spaced correctly in this context since [WordPress 5.4](https://make.wordpress.org/core/2020/02/13/an-updated-button-component-in-wordpress-5-4/). So I used an SVG from Material Icons as described in that link to WP 5.4.

### What Was Accomplished

- Added a custom format to the block editor using the WordPress Formats API.
  - It allows the use of the `<mark>` element to highlight text inside paragraphs.

### How To Test
- Write a post using the block editor.
- Used the formatting drop down to highlight something.
- Ensure its highlighted on the front-end.

### Screenshot

<img width="600" alt="Screen Shot 2021-01-27 at 12 22 14 PM" src="https://user-images.githubusercontent.com/226381/106028749-53acdd80-609a-11eb-88f8-c7fb5303b617.png">
