### PR TITLE
Fixes for Cata as a parent theme

### DIFF
--- a/includes/custom-formats/mark/class-mark.php
+++ b/includes/custom-formats/mark/class-mark.php
@@ -30,7 +30,7 @@ class Mark {
 			'cata-block-editor-format-mark',
 			get_template_directory_uri() . '/assets/dist/js/block-editor-format-mark.js',
 			array( 'wp-rich-text', 'wp-element', 'wp-editor', 'wp-compose', 'wp-data' ),
-			wp_get_theme()->get( 'Version' ),
+			wp_get_theme( 'cata' )->get( 'Version' ),
 			true
 		);
 	}

--- a/includes/custom-formats/mark/class-mark.php
+++ b/includes/custom-formats/mark/class-mark.php
@@ -28,7 +28,7 @@ class Mark {
 	public static function register_format() : void {
 		wp_register_script(
 			'cata-block-editor-format-mark',
-			get_stylesheet_directory_uri() . '/assets/dist/js/block-editor-format-mark.js',
+			get_template_directory_uri() . '/assets/dist/js/block-editor-format-mark.js',
 			array( 'wp-rich-text', 'wp-element', 'wp-editor', 'wp-compose', 'wp-data' ),
 			wp_get_theme()->get( 'Version' ),
 			true

--- a/includes/enqueue-assets/class-enqueue-assets.php
+++ b/includes/enqueue-assets/class-enqueue-assets.php
@@ -37,7 +37,7 @@ if ( ! class_exists( 'Cata\Enqueue_Assets' ) ) :
 		 * Output them in the head.
 		 */
 		public static function enqueue_styles_blocking() : void {
-			wp_enqueue_style( 'cata-blocking', get_template_directory_uri() . '/assets/dist/css/blocking.css', array(), wp_get_theme()->get( 'Version' ), 'screen' );
+			wp_enqueue_style( 'cata-blocking', get_template_directory_uri() . '/assets/dist/css/blocking.css', array(), wp_get_theme( 'cata' )->get( 'Version' ), 'screen' );
 		}
 
 		/**
@@ -45,7 +45,7 @@ if ( ! class_exists( 'Cata\Enqueue_Assets' ) ) :
 		 * Output them at the end of the body.
 		 */
 		public static function enqueue_styles_nonblocking() : void {
-			wp_enqueue_style( 'cata-nonblocking', get_template_directory_uri() . '/assets/dist/css/nonblocking.css', array(), wp_get_theme()->get( 'Version' ), 'screen' );
+			wp_enqueue_style( 'cata-nonblocking', get_template_directory_uri() . '/assets/dist/css/nonblocking.css', array(), wp_get_theme( 'cata' )->get( 'Version' ), 'screen' );
 		}
 
 	}


### PR DESCRIPTION
### What Was Accomplished

- Update Custom_Formats\Mark to use the `template` URI for assets instead of `stylesheet`. Template always refers to the top-level / parent, where stylesheet refers to the active theme which might be a child theme.
- When using `wp_get_theme` pass the theme slug. That way Cata's assets use its own version number, not the child theme.