### PR TITLE
Do Not Support Gradients in Parent Theme

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -46,6 +46,9 @@ if ( ! function_exists( 'cata_after_setup_theme' ) ) :
 		add_theme_support( 'wc-product-gallery-lightbox' );
 		add_theme_support( 'wc-product-gallery-slider' );
 
+		add_theme_support( 'disable-custom-gradients' );
+		add_theme_support( 'editor-gradient-presets', array() );
+
 		add_theme_support( 'disable-custom-font-sizes' );
 		add_theme_support( 'disable-custom-colors' );
 		add_theme_support( 


### PR DESCRIPTION
### What Was Accomplished

- Updated our action on `after_setup_theme` to remove support custom gradients, and declare no preset gradients.
  - My reasoning is that so far we only need gradients for the background of the cover block on Shop Catalog, and we can't remove the gradient selection from other blocks without adding JavaScript to the editor. I'm comfortable doing that on Shop Catalog since we actually need the gradients there, but it shouldn't also be added to any site where Cata is the parent theme.