### PR TITLE
Remove color palette, for now

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -51,51 +51,7 @@ if ( ! function_exists( 'cata_after_setup_theme' ) ) :
 
 		add_theme_support( 'disable-custom-font-sizes' );
 		add_theme_support( 'disable-custom-colors' );
-		add_theme_support( 
-			'editor-color-palette', 
-			array(
-				array(
-					'name'  => 'White',
-					'slug'  => 'white',
-					'color' => '#FFFFFF',
-				),
-				array(
-					'name'  => 'Gray Lightest',
-					'slug'  => 'gray-lightest',
-					'color' => '#fcfcfc',
-				),
-				array(
-					'name'  => 'Gray Lighter',
-					'slug'  => 'gray-lighter',
-					'color' => '#f8f8f8',
-				),
-				array(
-					'name'  => 'Gray Light',
-					'slug'  => 'gray-light',
-					'color' => '#dadada',
-				),
-				array(
-					'name'  => 'Gray Dark',
-					'slug'  => 'gray-dark',
-					'color' => '#848484',
-				),
-				array(
-					'name'  => 'Gray Darker',
-					'slug'  => 'gray-darker',
-					'color' => '#2b2b2b',
-				),
-				array(
-					'name'  => 'Gray Darkest',
-					'slug'  => 'gray-darkest',
-					'color' => '#0a0a0a',
-				),
-				array(
-					'name'  => 'Black',
-					'slug'  => 'black',
-					'color' => '#000000',
-				),
-			) 
-		);
+		add_theme_support( 'editor-color-palette', array() );
 
 		add_theme_support( 
 			'editor-font-sizes', 


### PR DESCRIPTION
### What Was Accomplished

- Reverted change from #52 that added a theme color palette. We might need the color palette in the child themes soon, but we don't need it this week, so let's do that in a separate and deliberate way.

@richdacuban Just so you know, I did this ^