### PR TITLE
Add a key to the mark custom format icon

### DIFF
--- a/assets/dist/js/block-editor-format-mark.js
+++ b/assets/dist/js/block-editor-format-mark.js
@@ -9,6 +9,7 @@
 	const icon = wp.element.createElement( 'svg', {
 		children: [
 			wp.element.createElement( 'path', {
+				key: 'cata-mark-icon',
 				d: 'M22,24H2v-4h20V24z M13.06,5.19l3.75,3.75L7.75,18H4v-3.75L13.06,5.19z M17.88,7.87l-3.75-3.75 l1.83-1.83c0.39-0.39,1.02-0.39,1.41,0l2.34,2.34c0.39,0.39,0.39,1.02,0,1.41L17.88,7.87z'
 			})
 		]


### PR DESCRIPTION
### Background

While adding a second custom format to Creepy Catalog, I encountered React key errors in the inline formats dropdown. In the dev environment, adding a key to both custom formats resolved this error.

### What Was Accomplished
- Added a key to the icon for the `<mark>` custom format.