### PR TITLE
Issue#105/2x1 crop image size

### DIFF
--- a/includes/images/image-sizes/class-image-sizes.php
+++ b/includes/images/image-sizes/class-image-sizes.php
@@ -28,6 +28,7 @@ class Image_Sizes {
 	public function __construct( Content_Width $content_width ) {
 		$this->content_width = $content_width;
 		add_action( 'after_setup_theme', array( $this, 'update_image_sizes' ) );
+		add_action( 'after_setup_theme', array( $this, 'add_image_sizes' ) );
 		add_filter( 'image_size_names_choose', array( $this, 'get_editor_image_sizes' ) );
 	}
 
@@ -63,6 +64,23 @@ class Image_Sizes {
 		add_theme_support( 'post-thumbnails' );
 		set_post_thumbnail_size( $__return_1280() );
 
+	}
+
+	/**
+	 * Add Image Sizes
+	 * Custom image sizes as opposed to the pre-named sizes in `update_image_sizes`
+	 */
+	public function add_image_sizes() : void {
+		/**
+		 * 2x1 cropped sizes for social images
+		 */
+		$sm = $this->content_width->smallest_unit * 3;
+		$md = $this->content_width->smallest_unit * 6;
+		$lg = $this->content_width->smallest_unit * 12;
+
+		add_image_size( 'cata_2x1_sm', $sm, ($sm / 2), true );	
+		add_image_size( 'cata_2x1_md', $md, ($md / 2), true );
+		add_image_size( 'cata_2x1_lg', $lg, ($lg / 2), true );
 	}
 
 	/**

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "cata",
-  "version": "0.7.4",
+  "version": "0.7.5-beta1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cata",
-  "version": "0.7.4",
+  "version": "0.7.5-beta1",
   "description": "WordPress theme, initially designed for Shop Catalog.",
   "main": "index.js",
   "scripts": {

--- a/style.css
+++ b/style.css
@@ -13,7 +13,7 @@
  * Author:      Thought & Expression Co. <devjobs@thought.is>
  * Author URI:  https://thought.is
  * Description: Initially designed for Shop Catalog.
- * Version:     0.7.4
+ * Version:     0.7.5-beta1
  * License:     GNU General Public License v2 or later
  * License URI: http://www.gnu.org/licenses/gpl-2.0.html
  * Text Domain: cata


### PR DESCRIPTION
### Related Issues
- Resolves #105 

### What Was Accomplished
- Added sm, md and lg version of a `cata_2x1_*` cropped image size.

### How It Was Tested
- [x] Local parent theme
- [x] Local child theme
- [X] Development child theme
