### PR TITLE
Disable Lazy Images in Embeds

### DIFF
--- a/includes/images/lazy-images/class-lazy-images.php
+++ b/includes/images/lazy-images/class-lazy-images.php
@@ -18,6 +18,7 @@ class Lazy_Images {
 	 */
 	public function __construct() {
 		add_action( 'wp_head', array( __CLASS__, 'update_lazy_image_actions' ) );
+		add_filter( 'lazyload_is_enabled', array( __CLASS__, 'disable_lazy_images' ) );
 	}
 
 	/**
@@ -32,4 +33,15 @@ class Lazy_Images {
 		add_action( 'wp_body_open', array( $lazy_images, 'setup_filters' ) );
 	}
 
+	/**
+	 * Disable Lazy Images
+	 * `the_post` action happens on embeds, setting up lazy images,
+	 * but the required js assets are not enqueued.
+	 *
+	 * @param bool $enabled
+	 * @return bool
+	 */
+	public static function disable_lazy_images( bool $enabled ) : bool {
+		return is_embed() ? false : $enabled;
+	}
 }

--- a/includes/images/placeholders/class-placeholders.php
+++ b/includes/images/placeholders/class-placeholders.php
@@ -23,7 +23,7 @@ class Placeholders {
 			return;
 		}
 
-		if ( is_feed() || is_preview() ) {
+		if ( is_feed() || is_preview() || is_embed() ) {
 			return;
 		}
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "cata",
-  "version": "0.7.5",
+  "version": "0.7.6-beta1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cata",
-  "version": "0.7.5",
+  "version": "0.7.6-beta1",
   "description": "WordPress theme, initially designed for Shop Catalog.",
   "main": "index.js",
   "scripts": {

--- a/style.css
+++ b/style.css
@@ -13,7 +13,7 @@
  * Author:      Thought & Expression Co. <devjobs@thought.is>
  * Author URI:  https://thought.is
  * Description: Initially designed for Shop Catalog.
- * Version:     0.7.5
+ * Version:     0.7.6-beta1
  * License:     GNU General Public License v2 or later
  * License URI: http://www.gnu.org/licenses/gpl-2.0.html
  * Text Domain: cata


### PR DESCRIPTION
### Related Issues
- Resolves #107 

### What Was Accomplished
- Added a filter on `` to disable lazy images during embed requests.

### How It Was Tested
- [x] Local theme development site
- [x] Local site using child theme
- [x] Remote site using child theme