### PR TITLE
Don’t support experimental layout in core/columns yes

### DIFF
--- a/includes/blocks/core-columns/class-core-columns.php
+++ b/includes/blocks/core-columns/class-core-columns.php
@@ -19,6 +19,7 @@ class Core_Columns {
 	 */
 	public function __construct() {
 		add_filter( 'render_block', array( __CLASS__, 'add_unit_class' ), 10, 2 );
+		add_filter( 'register_block_type_args', array( __CLASS__, 'do_not_support_experimental_layout' ), 10, 2 );
 	}
 
 	/**
@@ -86,5 +87,31 @@ class Core_Columns {
 
 	}
 
+	/**
+	 * Do Not Support Experimental Layout
+	 *
+	 * @param array $args
+	 * @param string $name
+	 * @return array $args
+	 */
+	public static function do_not_support_experimental_layout( array $args, string $name ) : array {
+		if ( 'core/columns' !== $name ) {
+			return $args;
+		}
+		if ( ! isset( $args['supports'] ) || ! isset( $args['supports']['__experimentalLayout'] ) ) {
+			return $args;
+		}
+		return array_merge(
+			$args,
+			array(
+				'supports' => array_merge(
+					$args['supports'],
+					array(
+						'__experimentalLayout' => false
+					)
+				)
+			)
+		);
+	}
 }
 


### PR DESCRIPTION
### Related Issues
- #125 
- This is the short term fix described in the issue

### What Was Accomplished
- Added a filter on `register_block_type_args` to set `supports.__experimentalLayout` to false for the `core/columns` block.
  - This stops `wp_render_layout_support_flag` from adding `flex-wrap: nowrap` to all `.wp-block-columns` 

### How It Was Tested
- [x] Local parent theme
- [ ] Local child theme
- [ ] Remote child theme

### How To Test
- [ ] When creating a `columns` block, you can set the width each `column` using `em` or `rem` units and they will wrap to a new line based on available space.