### PR TITLE
Issue#132/enable page excerpts

### DIFF
--- a/includes/bootstrap.php
+++ b/includes/bootstrap.php
@@ -25,3 +25,4 @@ if ( class_exists( 'Automattic\Jetpack\Jetpack_Lazy_Images' ) ) {
 new Languages();
 new Nav_Menus();
 new Sidebar();
+new Excerpts();

--- a/includes/excerpts/class-excerpts.php
+++ b/includes/excerpts/class-excerpts.php
@@ -1,0 +1,41 @@
+<?php
+/**
+ * Excerpts
+ * 
+ * @package Cata
+ * @since 0.7.15
+ */
+
+namespace Cata;
+
+/**
+ * Excerpts
+ */
+class Excerpts {
+	/**
+	 * Construct
+	 */
+	public function __construct() {
+		add_filter( 'excerpt_length', array( __CLASS__, 'excerpt_length' ), 10, 1 );
+		add_filter( 'excerpt_more', array( __CLASS__, 'excerpt_more' ) );
+	}
+
+	/**
+	 * Excerpt Length
+	 * 
+	 * @param int $length - number of words in excerpts.
+	 * @return int - number of words we'd like in excerpts.
+	 */
+	public static function excerpt_length( int $length ) : int {
+		return 21;
+	}
+
+	/**
+	 * Excerpt More
+	 * 
+	 * @return string - character(s) to use when truncating an excerpt to indicate it goes on.
+	 */
+	public static function excerpt_more() : string {
+		return '&hellip;';
+	}
+}

--- a/includes/excerpts/class-excerpts.php
+++ b/includes/excerpts/class-excerpts.php
@@ -16,8 +16,16 @@ class Excerpts {
 	 * Construct
 	 */
 	public function __construct() {
+		add_action( 'init', array( __CLASS__, 'add_excerpt_support' ), 20 );
 		add_filter( 'excerpt_length', array( __CLASS__, 'excerpt_length' ), 10, 1 );
 		add_filter( 'excerpt_more', array( __CLASS__, 'excerpt_more' ) );
+	}
+	
+	/**
+	 * Add Excerpt Support
+	 */
+	public static function add_excerpt_support() : void {
+		add_post_type_support( 'page', 'excerpt' );
 	}
 
 	/**

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "cata",
-  "version": "0.7.14",
+  "version": "0.7.15-beta1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "cata",
-  "version": "0.7.15-beta1",
+  "version": "0.7.15",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cata",
-  "version": "0.7.14",
+  "version": "0.7.15-beta1",
   "description": "WordPress theme, initially designed for Shop Catalog.",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cata",
-  "version": "0.7.15-beta1",
+  "version": "0.7.15",
   "description": "WordPress theme, initially designed for Shop Catalog.",
   "main": "index.js",
   "scripts": {

--- a/style.css
+++ b/style.css
@@ -13,7 +13,7 @@
  * Author:      Thought & Expression Co. <devjobs@thought.is>
  * Author URI:  https://thought.is
  * Description: Initially designed for Shop Catalog.
- * Version:     0.7.15-beta1
+ * Version:     0.7.15
  * License:     GNU General Public License v2 or later
  * License URI: http://www.gnu.org/licenses/gpl-2.0.html
  * Text Domain: cata

--- a/style.css
+++ b/style.css
@@ -13,7 +13,7 @@
  * Author:      Thought & Expression Co. <devjobs@thought.is>
  * Author URI:  https://thought.is
  * Description: Initially designed for Shop Catalog.
- * Version:     0.7.14
+ * Version:     0.7.15-beta1
  * License:     GNU General Public License v2 or later
  * License URI: http://www.gnu.org/licenses/gpl-2.0.html
  * Text Domain: cata


### PR DESCRIPTION
### Relevant Issues
- Closes #132 

### What Was Accomplished
- Added support for excerpts on pages
- Applied filters from Creepy Catalog to excerpts

### How It Was Tested
- [x] Locally on Cata
- [x] Locally on Creepy Catalog
- [x] Locally on Collective World

### How To Test
- The manual excerpt field appears in page settings in the editor.
- On the frontend, non-manual excerpts are no more than 21 words long and are truncated with "..."

### Deploy Steps
- Update theme version before merging