### PR TITLE
Remove extra paragraphs from shortcodes

### DIFF
--- a/includes/sidebar/class-sidebar.php
+++ b/includes/sidebar/class-sidebar.php
@@ -19,6 +19,11 @@ if ( ! class_exists( 'Cata\Sidebar' ) ) :
 		 */
 		public function __construct() {
 			add_action( 'widgets_init', array( __CLASS__, 'register_sidebar' ) );
+			/**
+			 * @link https://github.com/thoughtis/cata/issues/180
+			 * @priority 10: after do_blocks, but before do_shortcode.
+			 */
+			add_filter( 'widget_block_content', 'shortcode_unautop' );
 		}
 
 		/**

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cata",
-  "version": "0.8.18-beta2",
+  "version": "0.8.18",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "cata",
-      "version": "0.8.18-beta2",
+      "version": "0.8.18",
       "license": "GPL-3.0-or-later",
       "devDependencies": {
         "@babel/core": "^7.12.10",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cata",
-  "version": "0.8.17",
+  "version": "0.8.18-beta1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "cata",
-      "version": "0.8.17",
+      "version": "0.8.18-beta1",
       "license": "GPL-3.0-or-later",
       "devDependencies": {
         "@babel/core": "^7.12.10",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cata",
-  "version": "0.8.18-beta1",
+  "version": "0.8.18-beta2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "cata",
-      "version": "0.8.18-beta1",
+      "version": "0.8.18-beta2",
       "license": "GPL-3.0-or-later",
       "devDependencies": {
         "@babel/core": "^7.12.10",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cata",
-  "version": "0.8.17",
+  "version": "0.8.18-beta1",
   "description": "WordPress theme, initially designed for Shop Catalog.",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cata",
-  "version": "0.8.18-beta1",
+  "version": "0.8.18-beta2",
   "description": "WordPress theme, initially designed for Shop Catalog.",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cata",
-  "version": "0.8.18-beta2",
+  "version": "0.8.18",
   "description": "WordPress theme, initially designed for Shop Catalog.",
   "main": "index.js",
   "scripts": {

--- a/style.css
+++ b/style.css
@@ -13,7 +13,7 @@
  * Author:      Thought & Expression Co. <devjobs@thought.is>
  * Author URI:  https://thought.is
  * Description: Initially designed for Shop Catalog.
- * Version:     0.8.18-beta2
+ * Version:     0.8.18
  * License:     GNU General Pblic License v2 or later
  * License URI: http://www.gnu.org/licenses/gpl-2.0.html
  * Text Domain: cata

--- a/style.css
+++ b/style.css
@@ -13,7 +13,7 @@
  * Author:      Thought & Expression Co. <devjobs@thought.is>
  * Author URI:  https://thought.is
  * Description: Initially designed for Shop Catalog.
- * Version:     0.8.17
+ * Version:     0.8.18-beta1
  * License:     GNU General Pblic License v2 or later
  * License URI: http://www.gnu.org/licenses/gpl-2.0.html
  * Text Domain: cata

--- a/style.css
+++ b/style.css
@@ -13,7 +13,7 @@
  * Author:      Thought & Expression Co. <devjobs@thought.is>
  * Author URI:  https://thought.is
  * Description: Initially designed for Shop Catalog.
- * Version:     0.8.18-beta1
+ * Version:     0.8.18-beta2
  * License:     GNU General Pblic License v2 or later
  * License URI: http://www.gnu.org/licenses/gpl-2.0.html
  * Text Domain: cata


### PR DESCRIPTION
### Related Issues
- Resolves #180 

### What Was Accomplished
- Added a filter on `widget_block_content` to remove `<p></p>` tags around shortcodes in the block based widget editor.

### How It Was Tested
- [x] Local parent theme environment
  - I added a made up shortcode to the block based widget editor since theres no shortcodes in the parent theme.
- [x] Local child theme environment
  - Tested with related articles in collective world theme.